### PR TITLE
minimize use of ranef(); try to keep model matrices sparse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Imports:
     ggplot2,
     blme,
     broom.mixed,
+    Matrix
 License: GPL (>=2)
 LazyData: true
 VignetteBuilder: knitr

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -178,8 +178,9 @@ buildModelMatrix <- function(model, newdata, which = "full"){
   newRE <- mkNewReTrms(object = model,
                          newdata = newdata, re.form, na.action="na.pass",
                          allow.new.levels = TRUE)
-  reMat <- t(as.matrix(newRE$Zt))
-  reMat <- as.matrix(reMat)
+  ## reMat <- t(as.matrix(newRE$Zt))
+  ## reMat <- as.matrix(reMat)
+  reMat <- Matrix::t(newRE$Zt)  ## what breaks if we keep this sparse???
   colnames(reMat) <- rownames(newRE$Zt)
   mm <- cbind(X, reMat)
   if(which == "full"){

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -273,7 +273,7 @@ mkNewReTrms <- function(object, newdata, re.form=NULL, na.action=na.pass,
     if (!allow.new.levels && any(vapply(ReTrms$flist, anyNA, NA)))
       stop("NAs are not allowed in prediction data",
            " for grouping variables unless allow.new.levels is TRUE")
-    ns.re <- names(re <- ranef(object))
+    ns.re <- names(re <- ranef(object, condVar = FALSE))
     nRnms <- names(Rcnms <- ReTrms$cnms)
     if (!all(nRnms %in% ns.re))
       stop("grouping factors specified in re.form that were not present in original model")

--- a/R/merPredict.R
+++ b/R/merPredict.R
@@ -203,9 +203,10 @@ predictInterval <- function(merMod, newdata, which=c("full", "fixed", "random", 
                             attr(reMeans, "dimnames")[[1]]
                             )
     if (j %in% names(newdata)) { # get around if names do not line up because of nesting
+      newdata.modelMatrix <- as.matrix(newdata.modelMatrix)  ## give up, sparse to dense now
       tmp <- cbind(as.data.frame(newdata.modelMatrix), var = newdata[, j])
       tmp <- tmp[, !duplicated(colnames(tmp))]
-      keep <- names(tmp)[names(tmp) %in% dimnames(REcoefs)[[2]]]
+      keep <- names(tmp)[names(tmp) %in% colnames(REcoefs)]
       if (length(keep) == 0) {
         keep <- grep(dimnames(REcoefs)[[2]], names(tmp), value = TRUE)
       }

--- a/R/merPredict.R
+++ b/R/merPredict.R
@@ -154,11 +154,12 @@ predictInterval <- function(merMod, newdata, which=c("full", "fixed", "random", 
   # When there is no fixed effect intercept but there is a group level intercept
   # We need to do something!
 
+  rr <- ranef(merMod, condVar = TRUE)
   re.xb <- vector(getME(merMod, "n_rfacs"), mode = "list")
   names(re.xb) <- names(ngrps(merMod))
   for (j in names(re.xb)){
-    reMeans <- as.matrix(ranef(merMod)[[j]])
-    reMatrix <- attr(ranef(merMod, condVar = TRUE)[[j]], which = "postVar")
+    reMeans <- as.matrix(rr[[j]])
+    reMatrix <- attr(rr[[j]], which = "postVar")
     # OK, let's knock out all the random effects we don't need
     if (j %in% names(newdata)){ # get around if names do not line up because of nesting
       obslvl <- unique(as.character(newdata[, j]))
@@ -346,7 +347,7 @@ predictInterval <- function(merMod, newdata, which=c("full", "fixed", "random", 
 
       groupExtraPrecision <- 0
       groupVar <- (attr(VarCorr(merMod)[[j]],"stddev")["(Intercept)"])^2
-      reMatrix <- attr(ranef(merMod, condVar = TRUE)[[j]], which = "postVar")
+      reMatrix <- attr(rr[[j]], which = "postVar")
       for (eff in 1:dim(reMatrix)[3]) {
         term <- 1/(reMatrix[1,1,eff] + groupVar)
         if (term > 0) {

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -118,7 +118,7 @@ test_that("Build model matrix produces matrices of the right size", {
   d$fitted <- predict(g1, d)
 
   mm <- merTools:::buildModelMatrix(g1, newdata = d, which = "full")
-  expect_is(mm, "matrix")
+  expect_true(inherits(mm, "matrix") || inherits(mm, "Matrix"))
   expect_equal(dim(mm), c(2500, 15))
 
 }


### PR DESCRIPTION
This is related to #119, but also mixes in some (possibly misguided) attempts to avoid converting sparse to dense matrices. The latter isn't quite working because I haven't spent enough time understanding the logic at the end of `predictInterval()` to see how the computations could be done without reverting to dense matrices ...

This should probably have been two separate PRs, and I can separate them if you want, but wanted to start the conversation. Except for a little bit of leftover mess at the point where I gave up on maintaining sparsity, this should be fine - it does resolve #119 I think (but, I couldn't actually run that example on my system, because I ran out of memory - which is why I was pissing around with sparse matrices).