### PR TITLE
Drop `dim` before calling `bind_rows()`

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -318,3 +318,20 @@ levelfun <- function(x,nl.n,allow.new.levels=FALSE) {
   }
   return(x)
 }
+
+undim <- function(x) {
+  dim <- dim(x)
+
+  if (is.null(dim)) {
+    return(x)
+  }
+
+  dim(x) <- NULL
+
+  if (length(dim) == 1L && !is.null(rownames(x))) {
+    # Preserve names of 1D arrays
+    names(x) <- rownames(x)
+  }
+
+  x
+}

--- a/R/merExtract.R
+++ b/R/merExtract.R
@@ -85,6 +85,7 @@ REsim <- function(merMod, n.sims = 200, oddsRatio = FALSE, seed=NULL){
   for(i in c(1:reDims)){
     zed <- apply(mysim@ranef[[i]], c(2, 3),
                  function(x) as.data.frame(x) %>% dplyr::summarise_all(.funs = c("mean", "median", "sd")))
+    zed <- undim(zed)
     zed <- bind_rows(zed)
     zed$X1 <- rep(dimnames(mysim@ranef[[i]])[[2]], length(dimnames(mysim@ranef[[i]])[[3]]))
     zed$X2 <- rep(dimnames(mysim@ranef[[i]])[[3]], each = length(dimnames(mysim@ranef[[i]])[[2]]))


### PR DESCRIPTION
We are working on the next vctrs release, targeted for Jan 15, and this package came up in our revdep analysis.

`vctrs::obj_is_list()` no longer returns `TRUE` for _list arrays_, which means that you can't pass a list array to things like `dplyr::bind_rows()`. Unfortunately `apply()` returns one of these in your case, so you must undim the result first.